### PR TITLE
スクレイピング

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -4,9 +4,17 @@ class HomesController < ApplicationController
   end
 
   def news
-   @agent = Mechanize.new
-   @page = @agent.get("https://hobby.dengeki.com/")
-   @elements = @page.search('a')
+   #@agent = Mechanize.new
+   #@page = @agent.get("https://hobby.dengeki.com/tag/gunpla-2/")
+   #@elements = @page.search('div.topnews')
+   agent = Mechanize.new
+   page = agent.get("https://hobby.dengeki.com/tag/gunpla-2/")
+   @elements = page.at('div.topnews')
+   # elements.css('.ttlB').children.first.attributes['href'].value
+   # @elements.class
+   # @elements.methods
+   # @elements.css('.ttlB').methods
+   @elements = @elements.css('.ttlB').children
   end
 
 end

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -4,17 +4,10 @@ class HomesController < ApplicationController
   end
 
   def news
-   #@agent = Mechanize.new
-   #@page = @agent.get("https://hobby.dengeki.com/tag/gunpla-2/")
-   #@elements = @page.search('div.topnews')
    agent = Mechanize.new
-   page = agent.get("https://hobby.dengeki.com/tag/gunpla-2/")
-   @elements = page.at('div.topnews')
-   # elements.css('.ttlB').children.first.attributes['href'].value
-   # @elements.class
-   # @elements.methods
-   # @elements.css('.ttlB').methods
-   @elements = @elements.css('.ttlB').children
+   page = agent.get("https://hobby.dengeki.com/tag/gunpla-2/") #urlの情報取得
+   @elements = page.at('div.topnews')  #atメソッドでdivクラスのtopnews内の情報を指定
+   @elements = @elements.css('.ttlB').children  #cssメソッドでttlbの子要素を取得
   end
 
 end

--- a/app/views/hobby_images/show.html.erb
+++ b/app/views/hobby_images/show.html.erb
@@ -1,5 +1,5 @@
-<h1>投稿詳細</h1>
 <div class="container">
+<h1>投稿詳細</h1>
  <div class="row">
   <div class="col-sm-7">
    <!--投稿画像-->

--- a/app/views/homes/news.html.erb
+++ b/app/views/homes/news.html.erb
@@ -4,8 +4,10 @@
 <% @elements.each do|element| %>
  <ul>
   <li>
-    <!--.inner_textでテキスト部分を、element[:href]で属性を持ってくる。今回はaタグ。-->
-    <%= link_to element.inner_text, element[:href] %>
+    <!--.inner_textでテキスト部分を、attributesでを持ってくる。-->
+    <%= link_to element.children.inner_text, element.attributes['href'].value %>
+    <%#= element.attributes['href'].value %>
+    <%#= element.children.inner_text.inspect %>
   </li>
  </ul>
 <%end%>

--- a/app/views/homes/news.html.erb
+++ b/app/views/homes/news.html.erb
@@ -1,15 +1,11 @@
 <div class="container">
-
 <h1>News</h1><h5>(電撃ホビーWebへ飛びます)</h5>
 <% @elements.each do|element| %>
  <ul>
   <li>
-    <!--.inner_textでテキスト部分を、attributesでを持ってくる。-->
+    <!--.inner_textでテキスト部分を、attributesでurlを持ってくる。-->
     <%= link_to element.children.inner_text, element.attributes['href'].value %>
-    <%#= element.attributes['href'].value %>
-    <%#= element.children.inner_text.inspect %>
   </li>
  </ul>
 <%end%>
-
 </div>

--- a/app/views/homes/top.html.erb
+++ b/app/views/homes/top.html.erb
@@ -1,5 +1,4 @@
 <div class="container">
-
 <h1>Hobby Graph</h1>
 <p>
    Hobby Graphはプラモデルなど玩具好きの為のsnsです。<br>
@@ -7,5 +6,4 @@
    登録しなくても閲覧は可能です！<br>
    皆さんで盛り上げていきましょう！！
 </p>
-
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,5 @@
-<h1>マイページ</h1>
 <div class="container">
+<h1>マイページ</h1>
  <div class="row">
   <div class="col-sm-4">
    <!--プロフィール画像-->


### PR DESCRIPTION
コメントを追加して、レイアウトを変更しました。
・スクレイピングcontrollerを実装した手順
①スクレイピングはまず検証ページで情報の欲しい部分(divのtopnews)を探します。
②それだけだとその部分全部が1個の塊になって表示されてしまうので、
個々に分割するためにlogger.debug(@elements.inspect)を下に配置して、ログの詳細を探します(ttlB)。
③rails cの@elements.methodsでcssメソッドを見つける。
④css('.ttlB').childrenで①で塊だった個々を取得。

・スクレイピングviewの実装した手順
①element.children.inner_textで文字列を取得する。
②element.attributes['href'].valueでurlを取得する。
